### PR TITLE
hello-world: fix invalid uuid

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
       "slug": "hello-world",
       "topics": null,
       "unlocked_by": null,
-      "uuid": "53156fc9-0945-f080-08a9-ce269bfc9121a5d2c5c"
+      "uuid": "3ff87d76-5566-45f6-a5a9-549565aa0002"
     },
     {
       "core": false,


### PR DESCRIPTION
configlet temporarily generated invalid uuids. It looks as though `hello-world` has one of these invalid uuids.