### PR TITLE
hello-world: Generate missing exercise README

### DIFF
--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -1,0 +1,41 @@
+# Hello World
+
+The classical introductory exercise. Just say "Hello, World!".
+
+["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
+the traditional first program for beginning programming in a new language
+or environment.
+
+The objectives are simple:
+
+- Write a function that returns the string "Hello, World!".
+- Run the test suite and make sure that it succeeds.
+- Submit your solution and check it at the website.
+
+If everything goes well, you will be ready to fetch your first real exercise.
+
+## Setup
+
+Go through the setup instructions for PL/SQL to get ready to code:
+
+http://exercism.io/languages/plsql
+
+## Running the Tests
+
+Execute the tests by calling the `run` method in the respective `ut_<exercise>#` package.
+The necessary code should be contained at the end of the test package.
+As an example, the test for the _hamming_ exercise would be run using
+
+```
+begin
+  ut_hamming#.run;
+end;
+/
+```
+
+## Source
+
+This is an exercise to introduce users to using Exercism [http://en.wikipedia.org/wiki/%22Hello,_world!%22_program](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
In preparation for [v2](https://github.com/exercism/v2-feedback/blob/master/README.md) we're updating Configlet—our Exercism track linter—to require that we generate the exercise README. This is because in v2 we will not be generating READMEs on the fly, but deliver the README as defined in the directory for each implementation.

I'm going to go ahead and merge this as soon as the build passes, as this is janitorial work rather than a language-specific change.

See https://github.com/exercism/configlet/issues/116 for more details.