### PR TITLE
Reformat config files

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,96 +1,96 @@
 {
+  "language": "PL/SQL",
   "active": true,
+  "blurb": "",
+  "test_pattern": "ut.*plsql",
   "exercises": [
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "hello-world",
-      "topics": null,
+      "uuid": "53156fc9-0945-f080-08a9-ce269bfc9121a5d2c5c",
+      "core": false,
       "unlocked_by": null,
-      "uuid": "53156fc9-0945-f080-08a9-ce269bfc9121a5d2c5c"
+      "difficulty": 1,
+      "topics": null
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "hamming",
-      "topics": null,
+      "uuid": "b779f211-ecec-45cc-8641-e7cf87ff66ce",
+      "core": false,
       "unlocked_by": null,
-      "uuid": "b779f211-ecec-45cc-8641-e7cf87ff66ce"
+      "difficulty": 1,
+      "topics": null
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "gigasecond",
-      "topics": null,
+      "uuid": "6722fe30-30d2-4e99-87de-03b1a6eee0d6",
+      "core": false,
       "unlocked_by": null,
-      "uuid": "6722fe30-30d2-4e99-87de-03b1a6eee0d6"
+      "difficulty": 1,
+      "topics": null
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "rna-transcription",
-      "topics": null,
+      "uuid": "eec6c29b-fbbb-48d5-a0e9-4c902281390e",
+      "core": false,
       "unlocked_by": null,
-      "uuid": "eec6c29b-fbbb-48d5-a0e9-4c902281390e"
+      "difficulty": 1,
+      "topics": null
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "raindrops",
-      "topics": null,
+      "uuid": "2eaf11fe-e56e-4512-b8af-8fb637582a5e",
+      "core": false,
       "unlocked_by": null,
-      "uuid": "2eaf11fe-e56e-4512-b8af-8fb637582a5e"
+      "difficulty": 1,
+      "topics": null
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "difference-of-squares",
-      "topics": null,
+      "uuid": "f630b17b-59c1-448b-8880-85bb0c72ba5a",
+      "core": false,
       "unlocked_by": null,
-      "uuid": "f630b17b-59c1-448b-8880-85bb0c72ba5a"
+      "difficulty": 1,
+      "topics": null
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "roman-numerals",
-      "topics": null,
+      "uuid": "fc75b71e-e3e6-43b2-940b-65c06a6f9bc5",
+      "core": false,
       "unlocked_by": null,
-      "uuid": "fc75b71e-e3e6-43b2-940b-65c06a6f9bc5"
+      "difficulty": 1,
+      "topics": null
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "nth-prime",
-      "topics": null,
+      "uuid": "bede5fe0-43bf-4483-9fc3-7030df042515",
+      "core": false,
       "unlocked_by": null,
-      "uuid": "bede5fe0-43bf-4483-9fc3-7030df042515"
+      "difficulty": 1,
+      "topics": null
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "leap",
-      "topics": null,
+      "uuid": "50e2a7c5-3f71-448d-b203-65b7c0e3d6d5",
+      "core": false,
       "unlocked_by": null,
-      "uuid": "50e2a7c5-3f71-448d-b203-65b7c0e3d6d5"
+      "difficulty": 1,
+      "topics": null
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "grains",
-      "topics": null,
+      "uuid": "1d661c32-c75d-4c0b-bf88-ed0112bb1ab2",
+      "core": false,
       "unlocked_by": null,
-      "uuid": "1d661c32-c75d-4c0b-bf88-ed0112bb1ab2"
+      "difficulty": 1,
+      "topics": null
     },
     {
-      "core": false,
-      "difficulty": 1,
       "slug": "binary",
-      "topics": null,
+      "uuid": "6277f225-5d28-45f1-b020-9b821150ecfe",
+      "core": false,
       "unlocked_by": null,
-      "uuid": "6277f225-5d28-45f1-b020-9b821150ecfe"
+      "difficulty": 1,
+      "topics": null
     }
-  ],
-  "foregone": [],
-  "language": "PL/SQL",
-  "test_pattern": "ut.*plsql"
+  ]
 }

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -1,15 +1,15 @@
 {
+  "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md",
   "maintainers": [
     {
       "github_username": "chezwicker",
-      "show_on_website": false,
       "alumnus": false,
+      "show_on_website": false,
       "name": null,
-      "bio": null,
       "link_text": null,
       "link_url": null,
-      "avatar_url": null
+      "avatar_url": null,
+      "bio": null
     }
-  ],
-  "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md"
+  ]
 }


### PR DESCRIPTION
This runs the configlet fmt command, which normalizes the
contents and ordering of keys in the track config and
maintainers config.

This will let us script changes to the config files without
having unnecessary noise in the diffs when submitting pull
requests.

See exercism/meta#95