### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 You'll need access to a mounted Oracle DB. If you don't have one already
 installed, here are a few options:
 * get a free workspace at https://apex.oracle.com

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,4 +1,4 @@
-## Recommended Learning Resources
+# Recommended Learning Resources
 
 Exercism provides exercises and feedback but there are a number of resources
 that can help you get started more smoothely:

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 * [Oracle - PL/SQL Language Reference    ](http://docs.oracle.com/cd/E11882_01/appdev.112/e25519/toc.htm)
 * [Builtin Function Reference](http://psoug.org/reference/builtin_functions.html)
 * [Ask Tom](https://asktom.oracle.com/) - Advice by the PL/SQL Guru

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,2 +1,4 @@
+# Tests
+
 The command to execute the tests for each problem will be part of the test
 file. To run the test, you need to be connected to a mounted Oracle DB.


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
