### PR TITLE
Make README title match Exercism track name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xPL/SQL
+# Exercism PL/SQL Track
 
 Exercism exercises in Oracle PL/SQL
 


### PR DESCRIPTION
In the early days of Exercism we named each track for the
programming language, prefixed with an 'x'. This was reflected
in the name of the repository as well as the title of the README.

At some point we changed this decision, and renamed all the
repositories.

Over time most of the READMEs have also been updated.

This removes the now-defunct prefix from the README title.

Ref: exercism/exercism#6363